### PR TITLE
Support HTTPS proxy & custom CA bundles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0] - 2021-03-23
+### Added
+- Support an HTTPS proxy & custom certificates
+
+### Changed
+- The verify_cert keyword argument has been renamed to verify
+
+## [1.0.1] - 2021-03-17
+## Added
+- First PyPI release

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ flake8:
 
 .PHONY: pytest
 pytest:
-	$(VENV_PATH)/bin/pip uninstall -y osirium-ppa-api
+	$(VENV_PATH)/bin/pip uninstall -y ppa-api
 	$(VENV_PATH)/bin/pip install -e ".[test]"
 	$(VENV_PATH)/bin/pytest tests/ --cov-report term --cov=ppa_api
 	$(VENV_PATH)/bin/coverage html

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ By default no proxy or custom certificate will be used, & the server's TLS certi
 
 To skip certificate verification completely, supply the `verify` keyword argument as `False`.
 
-The PPA version is checked when creating a `PPAClient` instance, so any proxy or certificate errors will be raised early.
+The PPA version is checked during `PPAClient` instantiation, & any proxy/certificate errors will be raised early.
 
 # Code Examples
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,11 @@ from ppa_api.client import PPAClient
 ppa = PPAClient(address, api_key=api_key, verify="/path/to/ca-bundle")
 ```
 
-By default no proxy or custom certificate will be used, & the server's TLS certificate will be verified. 
+By default no proxy or custom certificate will be used, & the server's TLS certificate will be verified.
+
+To skip certificate verification completely, supply the `verify` keyword argument as `False`.
+
+The PPA version is checked when creating a `PPAClient` instance, so any proxy or certificate errors will be raised early.
 
 # Code Examples
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Python package for integrating with Osirium PPA's public API.
 - [Installation](#installation)
 - [Version Requirements](#version-requirements)
 - [Auth & Permissions](#authentication--permissions)
+- [Certificates & Proxies](#certificates-and-proxies)
 
 ### Example Scripts
 
@@ -100,6 +101,26 @@ If the code run without the relevant PPA permissions, it will raise [PermissionD
 PermissionDenied: Forbidden (403). The user associated with this API key does not have the required users permissions in PPA.
 ```
 
+## Certificates & Proxies
+
+You can supply a proxy address to the PPA client instance using the `proxy` keyword argument.
+
+```python
+from ppa_api.client import PPAClient
+
+ppa = PPAClient(address, api_key=api_key, proxy="my-https-proxy.net")
+```
+
+To use a custom certificate, use the `verify` keyword argument to supply a path to a CA bundle.
+
+```python
+from ppa_api.client import PPAClient
+
+ppa = PPAClient(address, api_key=api_key, verify="/path/to/ca-bundle")
+```
+
+By default no proxy or custom certificate will be used, & the server's TLS certificate will be verified. 
+
 # Code Examples
 
 ## Client
@@ -108,7 +129,7 @@ PermissionDenied: Forbidden (403). The user associated with this API key does no
 
 Creating a PPA client instance requires an `address`  & `api_key`.
 
-If there is no trusted certificate on PPA, you'll need to set the `verify_cert` keyword argument to `False`.
+If there is no trusted certificate on PPA, you'll need to set the `verify` keyword argument to `False`.
 
 #### Trusted Certificate
 
@@ -123,7 +144,7 @@ ppa = PPAClient(address, api_key=api_key)
 ```python
 from ppa_api.client import PPAClient
 
-ppa = PPAClient(address, api_key=api_key, verify_cert=False)
+ppa = PPAClient(address, api_key=api_key, verify=False)
 ```
 
 Skipping verification may generate the following log lines whenever a request is made:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Python package for integrating with Osirium PPA's public API.
 - [Installation](#installation)
 - [Version Requirements](#version-requirements)
 - [Auth & Permissions](#authentication--permissions)
-- [Certificates & Proxies](#certificates-and-proxies)
+- [Certificates & Proxies](#certificates--proxies)
 
 ### Example Scripts
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ from ppa_api.client import PPAClient
 ppa = PPAClient(address, api_key=api_key, proxy="my-https-proxy.net")
 ```
 
-To use a custom certificate, use the `verify` keyword argument to supply a path to a CA bundle.
+To use a custom certificate, supply the `verify` keyword argument with a path to a CA bundle.
 
 ```python
 from ppa_api.client import PPAClient

--- a/ppa_api/_client.py
+++ b/ppa_api/_client.py
@@ -79,8 +79,9 @@ def _get_request(
     api: Optional[str],
     endpoint: Optional[str] = None,
     api_key: str,
-    verify_cert: bool,
+    proxy: Optional[str],
     params: OptionalDict = None,
+    verify: Union[bool, str],
 ):
     return requests.get(
         urljoin(
@@ -89,7 +90,8 @@ def _get_request(
         ),
         params=params,
         headers={"Accept": "application/json", "Authorization": f"Bearer {api_key}"},
-        verify=verify_cert,
+        verify=verify,
+        proxies=proxy
     )
 
 
@@ -100,8 +102,9 @@ def _post_request(
     api: str,
     endpoint: str,
     api_key: str,
-    verify_cert: bool,
+    proxy: Optional[str],
     data: OptionalDict = None,
+    verify: Union[bool, str],
 ):
     return requests.post(
         urljoin(
@@ -110,7 +113,8 @@ def _post_request(
         ),
         headers={"Accept": "application/json", "Authorization": f"Bearer {api_key}"},
         json=data,
-        verify=verify_cert,
+        verify=verify,
+        proxies=proxy
     )
 
 

--- a/ppa_api/_client.py
+++ b/ppa_api/_client.py
@@ -77,11 +77,11 @@ def _get_request(
     *,
     address: str,
     api: Optional[str],
-    endpoint: Optional[str] = None,
+    endpoint: str,
     api_key: str,
     proxy: Optional[str],
-    params: OptionalDict = None,
     verify: Union[bool, str],
+    params: OptionalDict = None,
 ):
     return requests.get(
         urljoin(
@@ -103,8 +103,8 @@ def _post_request(
     endpoint: str,
     api_key: str,
     proxy: Optional[str],
-    data: OptionalDict = None,
     verify: Union[bool, str],
+    data: OptionalDict = None,
 ):
     return requests.post(
         urljoin(

--- a/ppa_api/client.py
+++ b/ppa_api/client.py
@@ -16,10 +16,18 @@ from .models import Image, Task, User, TaskResult
 
 
 class PPAClient:
-    def __init__(self, address: str, *, api_key: str, verify_cert: Optional[bool] = True) -> None:
+    def __init__(
+        self,
+        address: str,
+        *,
+        api_key: str,
+        verify: Optional[Union[bool, str]] = True,
+        proxy: Optional[str] = None,
+    ) -> None:
         self.address = address
         self.api_key = api_key
-        self.verify_cert = verify_cert
+        self.verify = verify
+        self.proxy = {"https": proxy} if proxy else None
 
         # Doing this on instantiation also checks the credentials for us.
         try:
@@ -34,7 +42,8 @@ class PPAClient:
         return api_method(
             address=self.address,
             api_key=self.api_key,
-            verify_cert=self.verify_cert,
+            verify=self.verify,
+            proxy=self.proxy,
             **kwargs,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ TEST_DEPENDENCIES = [
 
 setup(
     name="ppa-api",
-    version="1.0.1",  # https://semver.org/
+    version="2.0.0",  # https://semver.org/
     author="Osirium",
     maintainer="Tom Guyatt",
     author_email="supportdesk@osirium.com",


### PR DESCRIPTION
This PR:

- Renames the `verify_cert` kwarg to `verify`
- Passes the `verify` kwarg to requests directly so it can now be used to supply a CA bundle path
- Adds an optional `proxy` kwarg to support HTTPS proxies
- Updates the readme with instructions