### PR TITLE
Delayed tasks support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2021-05-01
+### Added
+- Add new delay_task method to create a delayed task (functionality introduced in PPA v2.8.0)
+
 ## [2.0.0] - 2021-03-23
 ### Added
 - Support an HTTPS proxy & custom certificates

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.0] - 2021-05-01
 ### Added
-- Add new delay_task method to create a delayed task (functionality introduced in PPA v2.8.0)
+- Add new delay_task, delayed_tasks, & delayed_task_by_id methods (functionality introduced in PPA v2.8.0)
+- All delayed task methods are wrapped with a PPA version decorator, & raise an exception if the PPA version is older than 2.8.0.
 
 ## [2.0.0] - 2021-03-23
 ### Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2021-05-01
+## [2.1.0-rc1] - 2021-03-25
 ### Added
 - Add new delay_task, delayed_tasks, & delayed_task_by_id methods (functionality introduced in PPA v2.8.0)
 - All delayed task methods are wrapped with a PPA version decorator, & raise an exception if the PPA version is older than 2.8.0.

--- a/README.md
+++ b/README.md
@@ -89,10 +89,6 @@ pip install ppa-api==2.1.0-rc1
 
 It is scheduled for release in May 2021.
 
-### Versions
-
-The current stable **release** 
-
 ## Version Requirements
 
 - PPA Appliance 2.7.1 or later

--- a/README.md
+++ b/README.md
@@ -71,9 +71,27 @@ The [examples](examples) folder contains scripts demonstrating the following ope
 
 ## Installation
 
-The package is on pypi and can be installed via pip:
+The package is on pypi and can be installed via pip.
 
-`pip install ppa-api`
+### Current Stable Release
+
+```
+pip install ppa-api==2.0.0
+```
+
+### Development Release
+
+The release candidate below supports delayed tasks (a new feature in PPA v2.8.0).
+
+It is scheduled for release on the 01/05/2021.
+
+```
+pip install ppa-api==2.1.0-rc1
+```
+
+### Versions
+
+The current stable **release** 
 
 ## Version Requirements
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ pip install ppa-api==2.0.0
 
 ### Development Release
 
-The release candidate below supports delayed tasks (a new feature in PPA v2.8.0).
-
-It is scheduled for release on the 01/05/2021.
+The current development candidate adds support for delayed tasks (a PPA v2.8.0 feature).
 
 ```
 pip install ppa-api==2.1.0-rc1
 ```
+
+It is scheduled for release in May 2021.
 
 ### Versions
 

--- a/ppa_api/_client.py
+++ b/ppa_api/_client.py
@@ -58,6 +58,7 @@ def api_call(func) -> Callable:
         response = func(address=address, api=api, endpoint=endpoint, **kwargs)
         try:
             response_json = response.json()
+            print(response.json())
         except json.decoder.JSONDecodeError:
             if response.status_code == 204:
                 # The request was processed but no data was returned.

--- a/ppa_api/_client.py
+++ b/ppa_api/_client.py
@@ -121,6 +121,7 @@ def _post_request(
 class API:
     base = functools.partial(_get_request, api=None)
     tasks = functools.partial(_get_request, api="rest", endpoint="tasks")
+    delayed_tasks = functools.partial(_get_request, api="rest", endpoint="delayed_tasks")
     users = functools.partial(_get_request, api="rest", endpoint="users")
     images = functools.partial(_get_request, api="rest", endpoint="images")
     revisions = functools.partial(_get_request, api="rest", endpoint="revisions")

--- a/ppa_api/_client.py
+++ b/ppa_api/_client.py
@@ -91,7 +91,7 @@ def _get_request(
         params=params,
         headers={"Accept": "application/json", "Authorization": f"Bearer {api_key}"},
         verify=verify,
-        proxies=proxy
+        proxies=proxy,
     )
 
 
@@ -114,7 +114,7 @@ def _post_request(
         headers={"Accept": "application/json", "Authorization": f"Bearer {api_key}"},
         json=data,
         verify=verify,
-        proxies=proxy
+        proxies=proxy,
     )
 
 

--- a/ppa_api/_client.py
+++ b/ppa_api/_client.py
@@ -3,6 +3,7 @@ import functools
 import json
 
 from uuid import UUID
+from distutils.version import StrictVersion
 from typing import Optional, Dict, Any, List, Union, Callable
 
 import requests
@@ -35,6 +36,20 @@ def validate_payload(payload: AnyJson) -> AnyJson:
     except TypeError:
         raise exceptions.ParameterError("The supplied payload cannot be converted to JSON.")
     return payload
+
+
+def minimum_version(minimum_version: str):
+    def _function_wrapper(method):
+        def _check_version(instance, *args, **kwargs):
+            if StrictVersion(minimum_version) > StrictVersion(instance.version):
+                raise exceptions.VersionError(
+                    f"The {method.__name__} method requires PPA version {minimum_version} or later, but your version is {instance.version}."
+                )
+            return method(instance, *args, **kwargs)
+
+        return _check_version
+
+    return _function_wrapper
 
 
 def api_call(func) -> Callable:

--- a/ppa_api/_client.py
+++ b/ppa_api/_client.py
@@ -58,7 +58,6 @@ def api_call(func) -> Callable:
         response = func(address=address, api=api, endpoint=endpoint, **kwargs)
         try:
             response_json = response.json()
-            print(response.json())
         except json.decoder.JSONDecodeError:
             if response.status_code == 204:
                 # The request was processed but no data was returned.

--- a/ppa_api/client.py
+++ b/ppa_api/client.py
@@ -77,6 +77,13 @@ class PPAClient:
     def delayed_tasks(self) -> List[DelayedTask]:
         return self._request(API.delayed_tasks)
 
+    @create.delayed_tasks
+    def delayed_task_by_id(self, delayed_task_id: int) -> Optional[DelayedTask]:
+        try:
+            return self._request(API.delayed_tasks, params={"id": f"eq.{delayed_task_id}"})[0]
+        except IndexError:
+            return None
+
     @create.tasks
     def task_by_uuid(self, uuid: str) -> Optional[Task]:
         try:
@@ -199,10 +206,12 @@ class PPAClient:
             raise exceptions.NoImageFound(
                 f"There are no images delegated to your identity with the name '{name}'."
             )
-        return self._request(
-            API.rpc,
-            endpoint="delay_task",
-            data={"image_name": name, "payload": payload, "description": description, "delay": delay},
+        return self.delayed_task_by_id(
+            self._request(
+                API.rpc,
+                endpoint="delay_task",
+                data={"image_name": name, "payload": payload, "description": description, "delay": delay},
+            )
         )
 
     def cancel_task(

--- a/ppa_api/client.py
+++ b/ppa_api/client.py
@@ -210,7 +210,12 @@ class PPAClient:
             self._request(
                 API.rpc,
                 endpoint="delay_task",
-                data={"image_name": name, "payload": payload, "description": description, "delay": delay},
+                data={
+                    "image_name": name,
+                    "payload": payload,
+                    "description": description,
+                    "delay": delay,
+                },
             )
         )
 

--- a/ppa_api/client.py
+++ b/ppa_api/client.py
@@ -201,7 +201,7 @@ class PPAClient:
         delay: int,
         description: str,
         payload: OptionalDict = None,
-    ) -> Task:
+    ) -> DelayedTask:
         if not self.image_by_name(name):
             raise exceptions.NoImageFound(
                 f"There are no images delegated to your identity with the name '{name}'."

--- a/ppa_api/client.py
+++ b/ppa_api/client.py
@@ -210,18 +210,25 @@ class PPAClient:
             raise exceptions.NoImageFound(
                 f"There are no images delegated to your identity with the name '{name}'."
             )
-        return self.delayed_task_by_id(
-            self._request(
-                API.rpc,
-                endpoint="delay_task",
-                data={
-                    "image_name": name,
-                    "payload": payload,
-                    "description": description,
-                    "delay": delay,
-                },
+        try:
+            return self.delayed_task_by_id(
+                self._request(
+                    API.rpc,
+                    endpoint="delay_task",
+                    data={
+                        "image_name": name,
+                        "payload": payload,
+                        "description": description,
+                        "delay": delay,
+                    },
+                )
             )
-        )
+        except exceptions.RequestError as e:
+            if "no deployed version found" in str(e).lower():
+                raise exceptions.ImageNotDeployed(
+                    f"The delayed task cannot be created as image '{name}' is not deployed."
+                )
+            raise e
 
     def cancel_task(
         self,

--- a/ppa_api/client.py
+++ b/ppa_api/client.py
@@ -11,6 +11,7 @@ from ._client import (
     validate_uuid,
     validate_payload,
     OptionalDict,
+    minimum_version,
 )
 from .models import Image, Task, DelayedTask, User, TaskResult
 
@@ -73,10 +74,12 @@ class PPAClient:
     def tasks(self) -> List[Task]:
         return self._request(API.tasks)
 
+    @minimum_version("2.8.0")
     @create.delayed_tasks
     def delayed_tasks(self) -> List[DelayedTask]:
         return self._request(API.delayed_tasks)
 
+    @minimum_version("2.8.0")
     @create.delayed_tasks
     def delayed_task_by_id(self, delayed_task_id: int) -> Optional[DelayedTask]:
         try:
@@ -194,6 +197,7 @@ class PPAClient:
             interval=interval,
         )
 
+    @minimum_version("2.8.0")
     def delay_task(
         self,
         name: str,

--- a/ppa_api/create.py
+++ b/ppa_api/create.py
@@ -2,7 +2,7 @@ import functools
 
 from typing import Callable, List, Optional, Union
 
-from .models import Image, Task, User, TaskResult
+from .models import Image, Task, DelayedTask, User, TaskResult
 
 
 def _creator(
@@ -47,6 +47,14 @@ def tasks(func: Callable) -> Callable:
         return _sort(_creator(Task, func(*args, **kwargs)), "started_at", reverse=True)
 
     return _task_creator
+
+
+def delayed_tasks(func: Callable) -> Callable:
+    @functools.wraps(func)
+    def _delayed_task_creator(*args, **kwargs) -> Optional[List[DelayedTask]]:
+        return _sort(_creator(DelayedTask, func(*args, **kwargs)), "start_time", reverse=True)
+
+    return _delayed_task_creator
 
 
 def users(func: Callable) -> Callable:

--- a/ppa_api/models.py
+++ b/ppa_api/models.py
@@ -36,6 +36,7 @@ Task = namedtuple(
         "stopped_at",
         "timed_out",
         "timeout",
+        "trigger",
         "username",
         "uuid",
     ],
@@ -45,19 +46,19 @@ Task = namedtuple(
 DelayedTask = namedtuple(
     "DelayedTask",
     [
-        'description',
-         'id',
-         'image',
-         'image_id',
-         'is_owner',
-         'is_pending',
-         'payload',
-         'start_time',
-         'task_uuid',
-         'timezone',
-         'trigger',
-         'username'
-    ]
+        "description",
+        "id",
+        "image",
+        "image_id",
+        "is_owner",
+        "is_pending",
+        "payload",
+        "start_time",
+        "task_uuid",
+        "timezone",
+        "trigger",
+        "username",
+    ],
 )
 
 User = namedtuple(

--- a/ppa_api/models.py
+++ b/ppa_api/models.py
@@ -41,6 +41,25 @@ Task = namedtuple(
     ],
 )
 
+
+DelayedTask = namedtuple(
+    "DelayedTask",
+    [
+        'description',
+         'id',
+         'image',
+         'image_id',
+         'is_owner',
+         'is_pending',
+         'payload',
+         'start_time',
+         'task_uuid',
+         'timezone',
+         'trigger',
+         'username'
+    ]
+)
+
 User = namedtuple(
     "User", ["active", "authenticated_at", "deleted_at", "email", "id", "name", "username"]
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ TEST_DEPENDENCIES = [
 
 setup(
     name="ppa-api",
-    version="2.0.0",  # https://semver.org/
+    version="2.1.0",  # https://semver.org/
     author="Osirium",
     maintainer="Tom Guyatt",
     author_email="supportdesk@osirium.com",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ TEST_DEPENDENCIES = [
 
 setup(
     name="ppa-api",
-    version="2.1.0",  # https://semver.org/
+    version="2.1.0-rc1",  # https://semver.org/
     author="Osirium",
     maintainer="Tom Guyatt",
     author_email="supportdesk@osirium.com",

--- a/tests/common.py
+++ b/tests/common.py
@@ -56,6 +56,11 @@ def mock_request(method: str, endpoint: str, responses):
         yield mocker
 
 
+def get_client(version="2.7.1"):
+    with mock_request("get", "version", mock_responses.VERSIONS[version]):
+        return client.PPAClient(ADDRESS, api_key=API_KEY)
+
+
 (
     IMAGES_MOCKER,
     REVISIONS_MOCKER,
@@ -76,8 +81,3 @@ DELAY_TASK_MOCKER, CANCEL_TASK_MOCKER, TASK_RESULT_MOCKER = list(
         ["delay_task", "cancel_task", "task_result"],
     )
 )
-
-
-def get_client(version="2.7.1"):
-    with mock_request("get", "version", mock_responses.VERSIONS[version]):
-        return client.PPAClient(ADDRESS, api_key=API_KEY)

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,14 +6,20 @@ from requests.utils import prepend_scheme_if_needed
 
 import requests_mock
 
+import mock_responses
+
+from ppa_api import client
+
 
 ADDRESS = "127.0.0.1"
-
+API_KEY = "dummy"
 ENDPOINTS = {
     "images": "/backend/v1/rest/images",
     "revisions": "/backend/v1/rest/revisions",
     "tasks": "/backend/v1/rest/tasks",
+    "delayed_tasks": "/backend/v1/rest/delayed_tasks",
     "start_task": "backend/v1/rest/rpc/start_task",
+    "delay_task": "/backend/v1/rest/rpc/delay_task",
     "cancel_task": "backend/v1/rest/rpc/cancel_task",
     "task_result": "backend/v1/rest/rpc/task_result",
     "version": "backend/v1/version",
@@ -55,6 +61,11 @@ REVISIONS_MOCKER = functools.partial(mock_request, "get", "revisions")
 VERSION_MOCKER = functools.partial(mock_request, "get", "version")
 USERS_MOCKER = functools.partial(mock_request, "get", "users")
 TASKS_MOCKER = functools.partial(mock_request, "get", "tasks")
-START_TASK_MOCKER = functools.partial(mock_request, "post", "start_task")
+DELAYED_TASKS_MOCKER = functools.partial(mock_request, "get", "delayed_tasks")
 CANCEL_TASK_MOCKER = functools.partial(mock_request, "post", "cancel_task")
 TASK_RESULT_MOCKER = functools.partial(mock_request, "post", "task_result")
+
+
+def get_client(version="2.7.1"):
+    with mock_request("get", "version", mock_responses.VERSIONS[version]):
+        return client.PPAClient(ADDRESS, api_key=API_KEY)

--- a/tests/common.py
+++ b/tests/common.py
@@ -56,14 +56,26 @@ def mock_request(method: str, endpoint: str, responses):
         yield mocker
 
 
-IMAGES_MOCKER = functools.partial(mock_request, "get", "images")
-REVISIONS_MOCKER = functools.partial(mock_request, "get", "revisions")
-VERSION_MOCKER = functools.partial(mock_request, "get", "version")
-USERS_MOCKER = functools.partial(mock_request, "get", "users")
-TASKS_MOCKER = functools.partial(mock_request, "get", "tasks")
-DELAYED_TASKS_MOCKER = functools.partial(mock_request, "get", "delayed_tasks")
-CANCEL_TASK_MOCKER = functools.partial(mock_request, "post", "cancel_task")
-TASK_RESULT_MOCKER = functools.partial(mock_request, "post", "task_result")
+(
+    IMAGES_MOCKER,
+    REVISIONS_MOCKER,
+    VERSION_MOCKER,
+    USERS_MOCKER,
+    TASKS_MOCKER,
+    DELAYED_TASKS_MOCKER,
+) = list(
+    map(
+        lambda endpoint: functools.partial(mock_request, "get", endpoint),
+        ["images", "revisions", "version", "users", "tasks", "delayed_tasks"],
+    )
+)
+
+DELAY_TASK_MOCKER, CANCEL_TASK_MOCKER, TASK_RESULT_MOCKER = list(
+    map(
+        lambda endpoint: functools.partial(mock_request, "post", endpoint),
+        ["delay_task", "cancel_task", "task_result"],
+    )
+)
 
 
 def get_client(version="2.7.1"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,33 +1,9 @@
 import logging
 import sys
 
-import pytest
-
-from ppa_api import client
-
-import mock_responses
-import common
-
-
 logging.basicConfig(
     stream=sys.stdout,
     level=logging.DEBUG,
     format="%(asctime)s %(module)s.%(funcName)s:%(lineno)d %(levelname)s: %(message)s",
 )
 logger = logging.getLogger(__name__)
-
-
-ADDRESS = "127.0.0.1"
-API_KEY = "dummy"
-
-
-@pytest.fixture
-def ppa():
-    with common.mock_request("get", "version", mock_responses.VERSIONS["2.7.1"]):
-        return client.PPAClient(ADDRESS, api_key=API_KEY)
-
-
-@pytest.fixture
-def ppa_unknown_version():
-    with common.mock_request("get", "version", mock_responses.NOT_FOUND_TEXT):
-        return client.PPAClient(ADDRESS, api_key=API_KEY)

--- a/tests/mock_responses.py
+++ b/tests/mock_responses.py
@@ -9,11 +9,20 @@ REQUEST_ERROR = {
     "status_code": 400,
 }
 
-MUST_BE_DEPLOYED = {
+TASK_MUST_BE_DEPLOYED = {
     "json": {
         "message": "This is a request error message",
         "hint": "Check the request data",
         "details": "Image must be deployed.",
+    },
+    "status_code": 400,
+}
+
+DELAY_MUST_BE_DEPLOYED = {
+    "json": {
+        "message": "This is a request error message",
+        "hint": "Check the request data",
+        "details": "No deployed version found.",
     },
     "status_code": 400,
 }
@@ -217,7 +226,47 @@ TASKS = {
     ],
 }
 
+DELAYED_TASKS = {
+    "status_code": 200,
+    "json": [
+        {
+            "id": 1,
+            "image": "Add User To Group",
+            "image_id": 1,
+            "description": "Adding John Smith to Remote Desktop Users",
+            "username": "test",
+            "task_uuid": "5069b766-0a8b-4721-8819-87d007c38db1",
+            "is_pending": False,
+            "is_owner": True,
+            "start_time": "2021-03-24T16:14:16.775347",
+            "timezone": "Etc/UTC",
+            "payload": None,
+            "has_payload": False,
+            "source": "api",
+            "parent_task_id": None,
+        },
+        {
+            "id": 2,
+            "image": "Remove User From Group",
+            "image_id": 1,
+            "description": "Removing John Smith from Remote Desktop Users",
+            "username": "admin",
+            "task_uuid": "9990056a-17b5-494a-8ae5-d3c84ca62d3b",
+            "is_pending": False,
+            "is_owner": True,
+            "start_time": "2021-03-24T20:14:16.942373",
+            "timezone": "Etc/UTC",
+            "payload": None,
+            "has_payload": False,
+            "source": "api",
+            "parent_task_id": None,
+        },
+    ]
+}
+
 TASK_STARTED = {"status_code": 200, "json": "fba5cc61-caf3-4620-a539-fcd7f4426abc"}
+
+TASK_DELAYED = {"status_code": 200, "json": 1}
 
 SUCCESSFUL_TASK = {"status_code": 200, "json": [TASKS["json"][0]]}
 
@@ -238,4 +287,5 @@ TASK_RESULT = {
 VERSIONS = {
     "2.7.0": {"status_code": 200, "json": {"appliance": "2.7.0"}},
     "2.7.1": {"status_code": 200, "json": {"appliance": "2.7.1"}},
+    "2.8.0": {"status_code": 200, "json": {"appliance": "2.8.0"}},
 }

--- a/tests/mock_responses.py
+++ b/tests/mock_responses.py
@@ -261,7 +261,7 @@ DELAYED_TASKS = {
             "source": "api",
             "parent_task_id": None,
         },
-    ]
+    ],
 }
 
 TASK_STARTED = {"status_code": 200, "json": "fba5cc61-caf3-4620-a539-fcd7f4426abc"}

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -82,14 +82,14 @@ EXCEPTIONS = {
         "unhandled_request_error",
     ],
 )
-def test_request_exceptions(ppa, mocker: Callable, mock_response: dict, exception_map_key: str):
+def test_request_exceptions(mocker: Callable, mock_response: dict, exception_map_key: str):
     exception_config = EXCEPTIONS[exception_map_key]
     with mocker(mock_response):
         with pytest.raises(exception_config.exception, match=exception_config.pattern):
-            ppa.images()
+            common.get_client().images()
 
 
-def test_credits_error(ppa):
+def test_credits_error():
     error_config = EXCEPTIONS["credits_required"]
     with common.mock_requests(
         [
@@ -99,7 +99,7 @@ def test_credits_error(ppa):
         ]
     ):
         with pytest.raises(error_config.exception, match=error_config.pattern):
-            ppa.start_task_async("test")
+            common.get_client().start_task_async("test")
 
 
 def test_unsupported_version():

--- a/tests/test_delayed_tasks.py
+++ b/tests/test_delayed_tasks.py
@@ -1,0 +1,118 @@
+from typing import Callable, Optional, List
+
+import pytest
+
+from ppa_api import exceptions, models
+
+import common
+import mock_responses
+
+
+TEST_NAME = "Dummy Task"
+TEST_ID = 1
+TASK_BY_ID_PARAMS = {"id": [f"eq.{TEST_ID}"]}
+
+UNSUPPORTED_PPA = common.get_client()
+# Delayed start is a 2.8.0 feature
+PPA = common.get_client("2.8.0")
+
+
+# Tests that only need a single mocked endpoint are parametrized, everything else is tested further down.
+@pytest.mark.parametrize(
+    "mocker, mock_response, instance_method, return_tests, query_string, request_body, expected_exception, exception_pattern",
+    [
+        [
+            common.DELAYED_TASKS_MOCKER,
+            mock_responses.DELAYED_TASKS,
+            lambda instance: instance.delayed_tasks(),
+            [lambda x: all([isinstance(item, models.DelayedTask) for item in x])],
+            None,
+            None,
+            None,
+            None,
+        ],
+        [
+            common.DELAYED_TASKS_MOCKER,
+            mock_responses.DELAYED_TASKS,
+            lambda instance: instance.delayed_task_by_id(TEST_ID),
+            [lambda x: isinstance(x, models.DelayedTask)],
+            TASK_BY_ID_PARAMS,
+            None,
+            None,
+            None,
+        ],
+        [
+            common.DELAYED_TASKS_MOCKER,
+            mock_responses.EMPTY_LIST,
+            lambda instance: instance.delayed_task_by_id(TEST_ID),
+            [lambda x: x is None],
+            TASK_BY_ID_PARAMS,
+            None,
+            None,
+            None,
+        ],
+    ],
+    ids=[
+        "all_delayed_tasks",
+        "delayed_task_by_id",
+        "delayed_task_by_id_none",
+    ],
+)
+def test_delay_task_requests(
+    mocker: Callable,
+    mock_response: dict,
+    instance_method: Callable,
+    return_tests: List[Callable],
+    query_string: Optional[dict],
+    request_body: Optional[dict],
+    expected_exception: Optional[Exception],
+    exception_pattern: Optional[str],
+):
+    with mocker(mock_response) as mock_adapter:
+        if expected_exception:
+            raises_kwargs = {"match": exception_pattern} if exception_pattern else {}
+            with pytest.raises(expected_exception, **raises_kwargs):
+                instance_method(PPA)
+        else:
+            result = instance_method(PPA)
+            assert all([test(result) for test in return_tests])
+            print(mock_adapter.request_history)
+            if query_string:
+                assert mock_adapter.request_history[0].qs == query_string
+            if request_body:
+                assert mock_adapter.request_history[0]._request.body.decode("utf-8") == request_body
+
+
+def test_delay_task():
+    with common.mock_requests(
+        [
+            ("get", "images", mock_responses.IMAGES),
+            ("get", "delayed_tasks", mock_responses.DELAYED_TASKS),
+            ("post", "delay_task", mock_responses.TASK_DELAYED),
+        ]
+    ):
+        PPA.delay_task("Dummy Task", delay=1, description="test")
+
+
+def test_must_be_deployed():
+    with common.mock_requests(
+        [
+            ("get", "images", mock_responses.TASKS),
+            ("post", "delay_task", mock_responses.DELAY_MUST_BE_DEPLOYED),
+        ]
+    ):
+        with pytest.raises(
+            exceptions.ImageNotDeployed,
+            match="The delayed task cannot be created as image 'Dummy Task' is not deployed.",
+        ):
+            PPA.delay_task("Dummy Task", delay=1, description="test")
+
+    # Test that a 400 error that isn't a deployment issue is raised with a generic exception.
+    with common.mock_requests(
+        [
+            ("get", "images", mock_responses.TASKS),
+            ("post", "delay_task", mock_responses.REQUEST_ERROR),
+        ]
+    ):
+        with pytest.raises(exceptions.RequestError):
+            PPA.delay_task("Dummy Task", delay=1, description="test")

--- a/tests/test_delayed_tasks.py
+++ b/tests/test_delayed_tasks.py
@@ -84,7 +84,6 @@ def test_delay_task_requests(
         else:
             result = instance_method(PPA)
             assert all([test(result) for test in return_tests])
-            print(mock_adapter.request_history)
             if query_string:
                 assert mock_adapter.request_history[0].qs == query_string
             if request_body:

--- a/tests/test_delayed_tasks.py
+++ b/tests/test_delayed_tasks.py
@@ -12,9 +12,17 @@ TEST_NAME = "Dummy Task"
 TEST_ID = 1
 TASK_BY_ID_PARAMS = {"id": [f"eq.{TEST_ID}"]}
 
-UNSUPPORTED_PPA = common.get_client()
 # Delayed start is a 2.8.0 feature
 PPA = common.get_client("2.8.0")
+
+
+def test_unsupported_version():
+    with pytest.raises(
+        exceptions.VersionError,
+        match="The delayed_tasks method requires PPA version 2.8.0 or later, but your version is 2.7.1.",
+    ):
+        # Make a client with default version 2.7.1.
+        common.get_client().delayed_tasks()
 
 
 # Tests that only need a single mocked endpoint are parametrized, everything else is tested further down.
@@ -92,6 +100,19 @@ def test_delay_task():
         ]
     ):
         PPA.delay_task("Dummy Task", delay=1, description="test")
+
+
+def test_delay_not_found():
+    with common.mock_requests(
+        [
+            ("get", "images", mock_responses.EMPTY_LIST),
+        ]
+    ):
+        with pytest.raises(
+            exceptions.NoImageFound,
+            match="There are no images delegated to your identity with the name 'Dummy Task'.",
+        ):
+            PPA.delay_task("Dummy Task", delay=1, description="test")
 
 
 def test_must_be_deployed():

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -12,6 +12,7 @@ IMAGE_NAME = "Dummy Image"
 IMAGE_BY_NAME_PARAMS = {"name": [f"eq.{IMAGE_NAME.lower()}"]}  # Gets lower-cased by requests-mock
 IMAGE_ID = 1
 IMAGE_BY_ID_PARAMS = {"id": [f"eq.{IMAGE_ID}"]}
+PPA = common.get_client()
 
 
 @pytest.mark.parametrize(
@@ -86,7 +87,6 @@ IMAGE_BY_ID_PARAMS = {"id": [f"eq.{IMAGE_ID}"]}
     ],
 )
 def test_image_requests(
-    ppa,
     mocker: Callable,
     mock_response: dict,
     instance_method: Callable,
@@ -94,7 +94,7 @@ def test_image_requests(
     query_string: Optional[str],
 ):
     with mocker(mock_response) as mock_adapter:
-        result = instance_method(ppa)
+        result = instance_method(PPA)
         assert all([test(result) for test in return_tests])
         if query_string:
             assert mock_adapter.request_history[0].qs == query_string

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -16,6 +16,7 @@ DELETED_USERS_PARAMS = {"select": SELECT_PARAMS, "deleted_at": ["not.is.null"]}
 LICENSED_USERS_PARAMS = {"select": SELECT_PARAMS, "deleted_at": ["is.null"], "active": ["eq.true"]}
 USER_BY_NAME_PARAMS = {"username": [f"ilike.*\\{TEST_NAME}"], "select": SELECT_PARAMS}
 USER_BY_ID_PARAMS = {"id": [f"eq.{TEST_ID}"], "select": SELECT_PARAMS}
+PPA = common.get_client()
 
 
 @pytest.mark.parametrize(
@@ -82,7 +83,6 @@ USER_BY_ID_PARAMS = {"id": [f"eq.{TEST_ID}"], "select": SELECT_PARAMS}
     ],
 )
 def test_user_requests(
-    ppa,
     mocker: Callable,
     mock_response: dict,
     instance_method: Callable,
@@ -90,7 +90,7 @@ def test_user_requests(
     query_string: Optional[str],
 ):
     with mocker(mock_response) as mock_adapter:
-        result = instance_method(ppa)
+        result = instance_method(PPA)
         assert all([test(result) for test in return_tests])
         if query_string:
             assert mock_adapter.request_history[0].qs == query_string


### PR DESCRIPTION
This PR adds support for the following PPA 2.8.0 features:

- Delaying a task
- Getting delayed start tasks

A minimum version decorator has been introduced to raise a `VersionError` if any delayed task method is called against a PPA appliance older than 2.8.0.

This is a pre-release version.