### PR TITLE
2.1.0-rc2: delayed tasks auditing improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.0-rc1] - 2021-03-25
 ### Added
-- Add new delay_task, delayed_tasks, & delayed_task_by_id methods (functionality introduced in PPA v2.8.0)
-- All delayed task methods are wrapped with a PPA version decorator, & raise an exception if the PPA version is older than 2.8.0.
+- Add new delayed task methods to support functionality introduced in PPA version 2.8.0
+- Delayed task methods will raise an exception if the PPA version is older than 2.8.0.
 
 ## [2.0.0] - 2021-03-23
 ### Added

--- a/ppa_api/client.py
+++ b/ppa_api/client.py
@@ -87,6 +87,21 @@ class PPAClient:
         except IndexError:
             return None
 
+    @minimum_version("2.8.0")
+    @create.delayed_tasks
+    def tasks_delayed_by_me(self) -> List[Task]:
+        return self._request(API.delayed_tasks, params={"is_owner": "eq.true"})
+
+    @minimum_version("2.8.0")
+    @create.delayed_tasks
+    def pending_delayed_tasks(self) -> List[Task]:
+        return self._request(API.delayed_tasks, params={"is_pending": "eq.true"})
+
+    @minimum_version("2.8.0")
+    @create.delayed_tasks
+    def processed_delayed_tasks(self) -> List[Task]:
+        return self._request(API.delayed_tasks, params={"is_pending": "eq.false"})
+
     @create.tasks
     def task_by_uuid(self, uuid: str) -> Optional[Task]:
         try:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ TEST_DEPENDENCIES = [
 
 setup(
     name="ppa-api",
-    version="2.1.0-rc1",  # https://semver.org/
+    version="2.1.0-rc2",  # https://semver.org/
     author="Osirium",
     maintainer="Tom Guyatt",
     author_email="supportdesk@osirium.com",

--- a/tests/test_delayed_tasks.py
+++ b/tests/test_delayed_tasks.py
@@ -23,16 +23,13 @@ def test_unsupported_version():
 
 # Tests that only need a single mocked endpoint are parametrized, everything else is tested further down.
 @pytest.mark.parametrize(
-    "mocker, mock_response, instance_method, return_tests, query_string, request_body, expected_exception, exception_pattern",
+    "mocker, mock_response, instance_method, return_tests, query_string",
     [
         [
             common.DELAYED_TASKS_MOCKER,
             mock_responses.DELAYED_TASKS,
             lambda instance: instance.delayed_tasks(),
             [lambda x: all([isinstance(item, models.DelayedTask) for item in x])],
-            None,
-            None,
-            None,
             None,
         ],
         [
@@ -41,9 +38,6 @@ def test_unsupported_version():
             lambda instance: instance.delayed_task_by_id(1),
             [lambda x: isinstance(x, models.DelayedTask)],
             {"id": ["eq.1"]},
-            None,
-            None,
-            None,
         ],
         [
             common.DELAYED_TASKS_MOCKER,
@@ -51,9 +45,6 @@ def test_unsupported_version():
             lambda instance: instance.delayed_task_by_id(1),
             [lambda x: x is None],
             {"id": ["eq.1"]},
-            None,
-            None,
-            None,
         ],
         [
             common.DELAYED_TASKS_MOCKER,
@@ -61,9 +52,6 @@ def test_unsupported_version():
             lambda instance: instance.tasks_delayed_by_me(),
             [lambda x: all([isinstance(item, models.DelayedTask) for item in x])],
             {"is_owner": ["eq.true"]},
-            None,
-            None,
-            None,
         ],
         [
             common.DELAYED_TASKS_MOCKER,
@@ -71,9 +59,6 @@ def test_unsupported_version():
             lambda instance: instance.pending_delayed_tasks(),
             [lambda x: all([isinstance(item, models.DelayedTask) for item in x])],
             {"is_pending": ["eq.true"]},
-            None,
-            None,
-            None,
         ],
         [
             common.DELAYED_TASKS_MOCKER,
@@ -81,9 +66,6 @@ def test_unsupported_version():
             lambda instance: instance.processed_delayed_tasks(),
             [lambda x: all([isinstance(item, models.DelayedTask) for item in x])],
             {"is_pending": ["eq.false"]},
-            None,
-            None,
-            None,
         ],
     ],
     ids=[
@@ -101,22 +83,12 @@ def test_delay_task_requests(
     instance_method: Callable,
     return_tests: List[Callable],
     query_string: Optional[dict],
-    request_body: Optional[dict],
-    expected_exception: Optional[Exception],
-    exception_pattern: Optional[str],
 ):
     with mocker(mock_response) as mock_adapter:
-        if expected_exception:
-            raises_kwargs = {"match": exception_pattern} if exception_pattern else {}
-            with pytest.raises(expected_exception, **raises_kwargs):
-                instance_method(PPA)
-        else:
-            result = instance_method(PPA)
-            assert all([test(result) for test in return_tests])
-            if query_string:
-                assert mock_adapter.request_history[0].qs == query_string
-            if request_body:
-                assert mock_adapter.request_history[0]._request.body.decode("utf-8") == request_body
+        result = instance_method(PPA)
+        assert all([test(result) for test in return_tests])
+        if query_string:
+            assert mock_adapter.request_history[0].qs == query_string
 
 
 def test_delay_task():

--- a/tests/test_delayed_tasks.py
+++ b/tests/test_delayed_tasks.py
@@ -74,7 +74,7 @@ def test_unsupported_version():
         "delayed_task_by_id_none",
         "tasks_delayed_by_me",
         "pending_delayed_tasks",
-        "processed_delayed_tasks"
+        "processed_delayed_tasks",
     ],
 )
 def test_delay_task_requests(

--- a/tests/test_delayed_tasks.py
+++ b/tests/test_delayed_tasks.py
@@ -8,10 +8,6 @@ import common
 import mock_responses
 
 
-TEST_NAME = "Dummy Task"
-TEST_ID = 1
-TASK_BY_ID_PARAMS = {"id": [f"eq.{TEST_ID}"]}
-
 # Delayed start is a 2.8.0 feature
 PPA = common.get_client("2.8.0")
 
@@ -42,9 +38,9 @@ def test_unsupported_version():
         [
             common.DELAYED_TASKS_MOCKER,
             mock_responses.DELAYED_TASKS,
-            lambda instance: instance.delayed_task_by_id(TEST_ID),
+            lambda instance: instance.delayed_task_by_id(1),
             [lambda x: isinstance(x, models.DelayedTask)],
-            TASK_BY_ID_PARAMS,
+            {"id": ["eq.1"]},
             None,
             None,
             None,
@@ -52,9 +48,39 @@ def test_unsupported_version():
         [
             common.DELAYED_TASKS_MOCKER,
             mock_responses.EMPTY_LIST,
-            lambda instance: instance.delayed_task_by_id(TEST_ID),
+            lambda instance: instance.delayed_task_by_id(1),
             [lambda x: x is None],
-            TASK_BY_ID_PARAMS,
+            {"id": ["eq.1"]},
+            None,
+            None,
+            None,
+        ],
+        [
+            common.DELAYED_TASKS_MOCKER,
+            mock_responses.DELAYED_TASKS,
+            lambda instance: instance.tasks_delayed_by_me(),
+            [lambda x: all([isinstance(item, models.DelayedTask) for item in x])],
+            {"is_owner": ["eq.true"]},
+            None,
+            None,
+            None,
+        ],
+        [
+            common.DELAYED_TASKS_MOCKER,
+            mock_responses.DELAYED_TASKS,
+            lambda instance: instance.pending_delayed_tasks(),
+            [lambda x: all([isinstance(item, models.DelayedTask) for item in x])],
+            {"is_pending": ["eq.true"]},
+            None,
+            None,
+            None,
+        ],
+        [
+            common.DELAYED_TASKS_MOCKER,
+            mock_responses.DELAYED_TASKS,
+            lambda instance: instance.processed_delayed_tasks(),
+            [lambda x: all([isinstance(item, models.DelayedTask) for item in x])],
+            {"is_pending": ["eq.false"]},
             None,
             None,
             None,
@@ -64,6 +90,9 @@ def test_unsupported_version():
         "all_delayed_tasks",
         "delayed_task_by_id",
         "delayed_task_by_id_none",
+        "tasks_delayed_by_me",
+        "pending_delayed_tasks",
+        "processed_delayed_tasks"
     ],
 )
 def test_delay_task_requests(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -9,9 +9,7 @@ import mock_responses
 
 
 IMAGE_NAME = "Dummy Image"
-IMAGE_BY_NAME_PARAMS = {"name": [f"eq.{IMAGE_NAME.lower()}"]}  # Gets lower-cased by requests-mock
 IMAGE_ID = 1
-IMAGE_BY_ID_PARAMS = {"id": [f"eq.{IMAGE_ID}"]}
 PPA = common.get_client()
 
 
@@ -37,7 +35,7 @@ PPA = common.get_client()
             mock_responses.IMAGES,
             lambda instance: instance.images_by_name(IMAGE_NAME),
             [lambda x: all([isinstance(item, models.Image) for item in x])],
-            IMAGE_BY_NAME_PARAMS,
+            {"name": [f"eq.{IMAGE_NAME.lower()}"]}  # Gets lower-cased by requests-mock,
         ],
         [
             common.REVISIONS_MOCKER,
@@ -51,7 +49,7 @@ PPA = common.get_client()
             mock_responses.IMAGES,
             lambda instance: instance.image_by_name(IMAGE_NAME),
             [lambda x: isinstance(x, models.Image)],
-            IMAGE_BY_NAME_PARAMS,
+            {"name": [f"eq.{IMAGE_NAME.lower()}"]}  # Gets lower-cased by requests-mock,
         ],
         [
             common.IMAGES_MOCKER,
@@ -65,7 +63,7 @@ PPA = common.get_client()
             mock_responses.IMAGES,
             lambda instance: instance.image_by_id(IMAGE_ID),
             [lambda x: isinstance(x, models.Image)],
-            IMAGE_BY_ID_PARAMS,
+            {"id": [f"eq.{IMAGE_ID}"]},
         ],
         [
             common.REVISIONS_MOCKER,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -13,8 +13,6 @@ import mock_responses
 TEST_NAME = "Dummy Task"
 TEST_UUID = str(uuid.uuid4())
 TASK_BY_UUID_PARAMS = {"uuid": [f"eq.{TEST_UUID}"]}
-TASK_BY_UUID_REQUEST_BODY = f'{{"uuid": "{TEST_UUID}"}}'
-STARTED_BY_ME_PARAMS = {"is_owner": ["eq.true"]}
 PPA = common.get_client()
 
 
@@ -47,7 +45,7 @@ PPA = common.get_client()
             mock_responses.TASKS,
             lambda instance: instance.tasks_started_by_me(),
             [lambda x: all([isinstance(item, models.Task) for item in x])],
-            STARTED_BY_ME_PARAMS,
+            {"is_owner": ["eq.true"]},
             None,
             None,
             None,
@@ -128,7 +126,7 @@ PPA = common.get_client()
             lambda instance: instance.cancel_task(TEST_UUID),
             [],
             None,
-            TASK_BY_UUID_REQUEST_BODY,
+            f'{{"uuid": "{TEST_UUID}"}}',
             None,
             None,
         ],
@@ -138,7 +136,7 @@ PPA = common.get_client()
             lambda instance: instance.cancel_task(TEST_UUID),
             [],
             None,
-            TASK_BY_UUID_REQUEST_BODY,
+            f'{{"uuid": "{TEST_UUID}"}}',
             exceptions.NoTaskFound,
             rf"Task with UUID '{TEST_UUID}' is either not running or does not exist\.",
         ],
@@ -148,7 +146,7 @@ PPA = common.get_client()
             lambda instance: instance.get_task_result(TEST_UUID),
             [],
             None,
-            TASK_BY_UUID_REQUEST_BODY,
+            f'{{"uuid": "{TEST_UUID}"}}',
             None,
             None,
         ],

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -11,11 +11,6 @@ import mock_responses
 TEST_NAME = "dummy"
 TEST_ID = 1
 SELECT_PARAMS = ["id,username,name,email,authenticated_at,active,deleted_at"]
-CURRENT_USERS_PARAMS = {"select": SELECT_PARAMS, "deleted_at": ["is.null"]}
-DELETED_USERS_PARAMS = {"select": SELECT_PARAMS, "deleted_at": ["not.is.null"]}
-LICENSED_USERS_PARAMS = {"select": SELECT_PARAMS, "deleted_at": ["is.null"], "active": ["eq.true"]}
-USER_BY_NAME_PARAMS = {"username": [f"ilike.*\\{TEST_NAME}"], "select": SELECT_PARAMS}
-USER_BY_ID_PARAMS = {"id": [f"eq.{TEST_ID}"], "select": SELECT_PARAMS}
 PPA = common.get_client()
 
 
@@ -27,49 +22,49 @@ PPA = common.get_client()
             mock_responses.USERS,
             lambda instance: instance.users(),
             [lambda x: all([isinstance(item, models.User) for item in x])],
-            CURRENT_USERS_PARAMS,
+            {"select": SELECT_PARAMS, "deleted_at": ["is.null"]},
         ],
         [
             common.USERS_MOCKER,
             mock_responses.USERS,
             lambda instance: instance.deleted_users(),
             [lambda x: all([isinstance(item, models.User) for item in x])],
-            DELETED_USERS_PARAMS,
+            {"select": SELECT_PARAMS, "deleted_at": ["not.is.null"]},
         ],
         [
             common.USERS_MOCKER,
             mock_responses.USERS,
             lambda instance: instance.licensed_users(),
             [lambda x: all([isinstance(item, models.User) for item in x])],
-            LICENSED_USERS_PARAMS,
+            {"select": SELECT_PARAMS, "deleted_at": ["is.null"], "active": ["eq.true"]},
         ],
         [
             common.USERS_MOCKER,
             mock_responses.USERS,
             lambda instance: instance.user_by_username(TEST_NAME),
             [lambda x: isinstance(x, models.User)],
-            USER_BY_NAME_PARAMS,
+            {"username": [f"ilike.*\\{TEST_NAME}"], "select": SELECT_PARAMS},
         ],
         [
             common.USERS_MOCKER,
             mock_responses.EMPTY_LIST,
             lambda instance: instance.user_by_username(TEST_NAME),
             [lambda x: x is None],
-            USER_BY_NAME_PARAMS,
+            {"username": [f"ilike.*\\{TEST_NAME}"], "select": SELECT_PARAMS},
         ],
         [
             common.USERS_MOCKER,
             mock_responses.USERS,
             lambda instance: instance.user_by_id(TEST_ID),
             [lambda x: isinstance(x, models.User)],
-            USER_BY_ID_PARAMS,
+            {"id": [f"eq.{TEST_ID}"], "select": SELECT_PARAMS},
         ],
         [
             common.USERS_MOCKER,
             mock_responses.EMPTY_LIST,
             lambda instance: instance.user_by_id(TEST_ID),
             [lambda x: x is None],
-            USER_BY_ID_PARAMS,
+            {"id": [f"eq.{TEST_ID}"], "select": SELECT_PARAMS},
         ],
     ],
     ids=[


### PR DESCRIPTION
This PR adds some more auditing methods for delayed tasks.

- tasks_delayed_by_me
- pending_delayed_tasks
- processed_delayed_tasks